### PR TITLE
Added filter options to have more control over the build files that get transpiled with swc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ export default {
   },
   plugins: [
     swc({
+      rollup: {
+        exclude: 'path/to/exclude/',
+      },
       jsc: {
         parser: {
           syntax: 'typescript',
@@ -38,7 +41,23 @@ export default {
 
 ## Options
 
-The plugin takes all the [SWC options](https://swc-project.github.io/docs/configuring-swc) except the `filename`.
+The plugin takes all the [SWC options](https://swc-project.github.io/docs/configuring-swc) except the `filename`. 
+
+In addition to the above `SWC Options`, it takes following options for smoother integration with the `rollup` plugin convention:
+
+### `rollup.exclude`
+
+Type: `String` | `Array[...String]`<br>
+Default: `null`
+
+A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+
+### `rollup.include`
+
+Type: `String` | `Array[...String]`<br>
+Default: `null`
+
+A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   "peerDependencies": {
     "@swc/core": ">=1.0",
     "rollup": ">=1.5.0"
+  },
+  "dependencies": {
+    "@rollup/pluginutils": "^4.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,12 @@ importers:
 
   .:
     specifiers:
+      '@rollup/pluginutils': ^4.1.1
       '@swc/core': ^1.2.62
       rollup: ^2.52.4
       typescript: ^4.3.4
+    dependencies:
+      '@rollup/pluginutils': 4.1.1
     devDependencies:
       '@swc/core': 1.2.62
       rollup: 2.52.4
@@ -61,6 +64,14 @@ packages:
       picomatch: 2.3.0
       rollup: 2.52.4
     dev: true
+
+  /@rollup/pluginutils/4.1.1:
+    resolution: {integrity: sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.0
+    dev: false
 
   /@swc/core-android-arm64/1.2.62:
     resolution: {integrity: sha512-RZYo5d5S8XnAbS/eBxnUxsVM8pYzCWkFAN1rJwSn7aVwnrfSYwdyIM6JFieyvUL69g5bOyjXgH9fY8XllV5V9A==}
@@ -206,6 +217,10 @@ packages:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
     dev: true
 
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: false
+
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -241,7 +256,6 @@ packages:
   /picomatch/2.3.0:
     resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /resolve/1.20.0:
     resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,34 @@
 import {Options, transform} from '@swc/core'
 import {Plugin} from 'rollup'
+import {createFilter, FilterPattern} from '@rollup/pluginutils';
 
-type PluginOptions<O = Options> = Pick<O, Exclude<keyof O, 'filename'>>
+type SWCPluginOptions<O = Options> = Pick<O, Exclude<keyof O, 'filename'>>;
 
-type RollupPluginSWC = (options?: PluginOptions) => Plugin
+type RollUpOptions = {
+  include: FilterPattern;
+  exclude: FilterPattern;
+};
 
-const swc: RollupPluginSWC = (options = {}) => ({
-  name: 'swc',
-  transform(code, filename) {
-    (options as PluginOptions & {filename: string}).filename = filename
-    return transform(code, options)
-  }
-})
+type PluginOptions = SWCPluginOptions & {rollup?: RollUpOptions};
+
+type RollupPluginSWC = (options?: PluginOptions) => Plugin;
+
+const swc: RollupPluginSWC = (pluginOptions = {}) => {
+  const {rollup, ...options} = pluginOptions;
+
+  const filter = createFilter(rollup?.include, rollup?.exclude);
+
+  return {
+    name: 'swc',
+    transform(code, filename) {
+      if (!filter(filename)) {
+        return null;
+      }
+
+      (options as SWCPluginOptions & {filename: string}).filename = filename;
+      return transform(code, options);
+    },
+  };
+};
 
 export default swc


### PR DESCRIPTION
This is to add support for the [filter options](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter) that is a convention with `rollup` plugins. This allows the users to selectively exclude/include files from getting transpiled with `swc`. 

I faced this as a blocker while switching from a project that was using `babel` with [filter options](https://github.com/rollup/plugins/tree/master/packages/babel#exclude), so raising this fix.